### PR TITLE
Update to piplin v1.0.2，Fix npm run error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-fpm-alpine
 
-LABEL version="1.0"
+LABEL version="v1.0.2"
 LABEL maintainer="Sheaven <sheaven@qq.com>, Guan Shiliang <guan.shiliang@gmail.com>"
 
 ARG piplin_ver
@@ -24,7 +24,7 @@ RUN set -xe \
 RUN set -xe; \
     curl -o ${piplin_ver}.tar.gz -fSL "https://github.com/Piplin/Piplin/archive/${piplin_ver}.tar.gz"; \
     tar xzvf ${piplin_ver}.tar.gz --strip-components=1; \
-    rm -r ${piplin_ver}.tar.gz
+    rm -r ${piplin_ver}.tar.gz composer.lock
 
 # 安装 composer
 RUN set -xe \
@@ -36,7 +36,7 @@ RUN set -xe \
 
 # 安装项目依赖
 RUN set -xe \
-    && apk add --no-cache nginx redis nodejs supervisor git bash openssh-client rsync \
+    && apk add --no-cache nginx redis nodejs nodejs-npm supervisor git bash openssh-client rsync \
     && npm config set registry http://registry.npm.taobao.org/ \
     && composer install -o \
     && npm install --production \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM php:7.1-fpm-alpine
 LABEL version="v1.0.2"
 LABEL maintainer="Sheaven <sheaven@qq.com>, Guan Shiliang <guan.shiliang@gmail.com>"
 
-ARG piplin_ver
-ENV piplin_ver ${piplin_ver:-1.0}
+ARG piplin_ver=v1.0.2
 
 RUN mkdir -p /var/www/piplin
 WORKDIR /var/www/piplin
@@ -52,6 +51,7 @@ COPY nginx/piplin.template /etc/nginx/conf.d/default.conf
 COPY .env.docker /var/www/piplin/.env
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
+VOLUME /var/www/piplin
 EXPOSE 80
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ $ git clone https://github.com/Piplin/Docker.git piplin-docker
 
 ## 构建
 
+>piplin_ver=v1.0.2 为 piplin 源码的版本号，可在 build 时定义，后期有新版本可直接修改为最新的 release 版本号 [查看最新版本](https://github.com/Piplin/Piplin/releases)
+
 ```
 $ cd piplin-docker
-$ docker build -t piplin:lite .
+$ docker build -t piplin:lite . --build-arg piplin_ver=v1.0.2
 ```
 
 ## 运行
 
 ```
-$ docker run -d -p 80:80 --name piplin piplin:lite
+$ docker run -d -p 80:80 -v piplin:/var/www/piplin --name piplin piplin:lite
 ```
 
 ## 访问
@@ -31,6 +33,7 @@ http://127.0.0.1 or http://piplin.app
 > 如果你要使用piplin.app访问，请预先在本机hosts配 127.0.0.1 piplin.app
 
 可通过修改下面2个文件中的相关配置进行域名变更（修改后需要重新构建）
+
 ```
 nginx/piplin.template
 .env.docker
@@ -51,11 +54,20 @@ nginx/piplin.template
 
 进入 web 容器
 
-`docker exec -it piplin bash`
+`docker exec -it piplin ash`
 
 ## 清理
->!!!注意以下操作会清理全部 Piplin Docker 数据，一般用于重新部署时用!!!
-```
-docker rm -f piplin
-docker rmi piplin:lite
-```
+
+* 删除容器，容器内的 /var/www/piplin 目录不会被删除，除非进行最后一步的 volume 删除操作
+
+`docker rm -f piplin`
+
+* 删除 build 的镜像
+
+`docker rmi piplin:lite`
+
+>!!!注意以下操作会清理全部 Piplin Docker 数据，并且无法恢复!!!
+
+* 删除 volume
+
+`docker volume rm piplin`


### PR DESCRIPTION
修复 npm 运行出错的问题；
解决 composer 安装时无法从镜像加速下载的问题；
增加在 build 时定义 piplin 版本号的功能；
增加 volume 卷定义，可持久保存运行数据，不跟随容器删除而清理；